### PR TITLE
[QT] Simplify Overview Balances

### DIFF
--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -200,7 +200,7 @@
                  <property name="frameShadow">
                   <enum>QFrame::Raised</enum>
                  </property>
-                 <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0">
+                 <layout class="QVBoxLayout" name="verticalLayout" stretch="0">
                   <property name="leftMargin">
                    <number>0</number>
                   </property>
@@ -213,199 +213,6 @@
                   <property name="bottomMargin">
                    <number>0</number>
                   </property>
-                  <item>
-                   <widget class="QFrame" name="frame_CombinedBalances">
-                    <property name="minimumSize">
-                     <size>
-                      <width>470</width>
-                      <height>0</height>
-                     </size>
-                    </property>
-                    <property name="frameShape">
-                     <enum>QFrame::StyledPanel</enum>
-                    </property>
-                    <property name="frameShadow">
-                     <enum>QFrame::Raised</enum>
-                    </property>
-                    <layout class="QVBoxLayout" name="verticalLayout_5">
-                     <item>
-                      <layout class="QHBoxLayout" name="horizontalLayout_5" stretch="0,0,0">
-                       <item>
-                        <widget class="QLabel" name="label_5z">
-                         <property name="minimumSize">
-                          <size>
-                           <width>0</width>
-                           <height>20</height>
-                          </size>
-                         </property>
-                         <property name="font">
-                          <font>
-                           <pointsize>12</pointsize>
-                           <weight>75</weight>
-                           <bold>true</bold>
-                          </font>
-                         </property>
-                         <property name="toolTip">
-                          <string>Combined Balance (including unconfirmed and immature coins)</string>
-                         </property>
-                         <property name="text">
-                          <string>Combined Balance</string>
-                         </property>
-                        </widget>
-                       </item>
-                       <item>
-                        <widget class="QLabel" name="labelWalletStatus">
-                         <property name="cursor">
-                          <cursorShape>WhatsThisCursor</cursorShape>
-                         </property>
-                         <property name="toolTip">
-                          <string>The displayed information may be out of date. Your wallet automatically synchronizes with the StakeCubeCoin network after a connection is established, but this process has not completed yet.</string>
-                         </property>
-                         <property name="styleSheet">
-                          <string notr="true">QLabel { color: red; }</string>
-                         </property>
-                         <property name="text">
-                          <string notr="true">(out of sync)</string>
-                         </property>
-                         <property name="alignment">
-                          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-                         </property>
-                        </widget>
-                       </item>
-                       <item>
-                        <spacer name="horizontalSpacer_1">
-                         <property name="orientation">
-                          <enum>Qt::Horizontal</enum>
-                         </property>
-                         <property name="sizeHint" stdset="0">
-                          <size>
-                           <width>40</width>
-                           <height>20</height>
-                          </size>
-                         </property>
-                        </spacer>
-                       </item>
-                      </layout>
-                     </item>
-                     <item>
-                      <widget class="Line" name="line_CombinedBalance">
-                       <property name="minimumSize">
-                        <size>
-                         <width>0</width>
-                         <height>1</height>
-                        </size>
-                       </property>
-                       <property name="maximumSize">
-                        <size>
-                         <width>16777215</width>
-                         <height>1</height>
-                        </size>
-                       </property>
-                       <property name="orientation">
-                        <enum>Qt::Horizontal</enum>
-                       </property>
-                      </widget>
-                     </item>
-                     <item>
-                      <layout class="QGridLayout" name="gridLayout_3">
-                       <property name="spacing">
-                        <number>12</number>
-                       </property>
-                       <item row="1" column="0">
-                        <widget class="QLabel" name="labelBalanceTextz">
-                         <property name="text">
-                          <string>Available:</string>
-                         </property>
-                        </widget>
-                       </item>
-                       <item row="1" column="1">
-                        <widget class="QLabel" name="labelBalancez">
-                         <property name="font">
-                          <font>
-                           <weight>75</weight>
-                           <bold>true</bold>
-                          </font>
-                         </property>
-                         <property name="cursor">
-                          <cursorShape>IBeamCursor</cursorShape>
-                         </property>
-                         <property name="toolTip">
-                          <string>Your current spendable balance</string>
-                         </property>
-                         <property name="text">
-                          <string notr="true">0.000 000 00 SCC</string>
-                         </property>
-                         <property name="alignment">
-                          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                         </property>
-                         <property name="textInteractionFlags">
-                          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-                         </property>
-                        </widget>
-                       </item>
-                       <item row="2" column="0">
-                        <widget class="QLabel" name="labelTotalTextz">
-                         <property name="text">
-                          <string>Total:</string>
-                         </property>
-                        </widget>
-                       </item>
-                       <item row="2" column="1">
-                        <widget class="QLabel" name="labelTotalz">
-                         <property name="font">
-                          <font>
-                           <weight>75</weight>
-                           <bold>true</bold>
-                          </font>
-                         </property>
-                         <property name="cursor">
-                          <cursorShape>IBeamCursor</cursorShape>
-                         </property>
-                         <property name="toolTip">
-                          <string>Total Balance, including all unavailable coins.</string>
-                         </property>
-                         <property name="text">
-                          <string notr="true">0.000 000 00 SCC</string>
-                         </property>
-                         <property name="alignment">
-                          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                         </property>
-                         <property name="textInteractionFlags">
-                          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-                         </property>
-                        </widget>
-                       </item>
-                       <item row="2" column="3">
-                        <spacer name="horizontalSpacer_2">
-                         <property name="orientation">
-                          <enum>Qt::Horizontal</enum>
-                         </property>
-                         <property name="sizeHint" stdset="0">
-                          <size>
-                           <width>40</width>
-                           <height>20</height>
-                          </size>
-                         </property>
-                        </spacer>
-                       </item>
-                      </layout>
-                     </item>
-                     <item>
-                      <spacer name="verticalSpacer_1">
-                       <property name="orientation">
-                        <enum>Qt::Vertical</enum>
-                       </property>
-                       <property name="sizeHint" stdset="0">
-                        <size>
-                         <width>20</width>
-                         <height>40</height>
-                        </size>
-                       </property>
-                      </spacer>
-                     </item>
-                    </layout>
-                   </widget>
-                  </item>
                   <item>
                    <widget class="QFrame" name="frame_Balances">
                     <property name="frameShape">
@@ -438,9 +245,21 @@
                         </widget>
                        </item>
                        <item>
-                        <widget class="QLabel" name="labelSCCPercent">
+                        <widget class="QLabel" name="labelWalletStatus">
+                         <property name="cursor">
+                          <cursorShape>WhatsThisCursor</cursorShape>
+                         </property>
+                         <property name="toolTip">
+                          <string>The displayed information may be out of date. Your wallet automatically synchronizes with the StakeCubeCoin network after a connection is established, but this process has not completed yet.</string>
+                         </property>
+                         <property name="styleSheet">
+                          <string notr="true">QLabel { color: red; }</string>
+                         </property>
                          <property name="text">
-                          <string notr="true">0 %</string>
+                          <string notr="true">(out of sync)</string>
+                         </property>
+                         <property name="alignment">
+                          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
                          </property>
                         </widget>
                        </item>
@@ -737,7 +556,7 @@
                        <item row="5" column="0">
                         <widget class="QLabel" name="labelTotalText">
                          <property name="toolTip">
-                          <string>Your current StakeCubeCoin balance, unconfirmed and immature transactions included</string>
+                          <string>Your current SCC balance, unconfirmed and immature transactions included</string>
                          </property>
                          <property name="text">
                           <string>Total:</string>
@@ -756,7 +575,7 @@
                           <cursorShape>IBeamCursor</cursorShape>
                          </property>
                          <property name="toolTip">
-                          <string>Your current StakeCubeCoin balance, unconfirmed and immature transactions included</string>
+                          <string>Your current SCC balance, unconfirmed and immature transactions included</string>
                          </property>
                          <property name="text">
                           <string notr="true">0.000 000 00 SCC</string>

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -196,12 +196,6 @@ void OverviewPage::setBalance(const CAmount& balance, const CAmount& unconfirmed
     CAmount phrAvailableBalance = balance - immatureBalance - nLockedBalance;
     CAmount nTotalWatchBalance = watchOnlyBalance + watchUnconfBalance + watchImmatureBalance;    
     CAmount nUnlockedBalance = nTotalBalance - nLockedBalance;
-    // Percentages
-    QString sPercentage = "";
-    getPercentage(nUnlockedBalance, sPercentage);
-    // Combined balances
-    CAmount availableTotalBalance = phrAvailableBalance;
-    CAmount sumTotalBalance = nTotalBalance;
 
     // SCC labels
     ui->labelBalance->setText(BitcoinUnits::floorHtmlWithUnit(nDisplayUnit, phrAvailableBalance, false, BitcoinUnits::separatorAlways));
@@ -217,19 +211,9 @@ void OverviewPage::setBalance(const CAmount& balance, const CAmount& unconfirmed
     ui->labelWatchLocked->setText(BitcoinUnits::floorHtmlWithUnit(nDisplayUnit, nWatchOnlyLockedBalance, false, BitcoinUnits::separatorAlways));
     ui->labelWatchTotal->setText(BitcoinUnits::floorHtmlWithUnit(nDisplayUnit, nTotalWatchBalance, false, BitcoinUnits::separatorAlways));
 
-    // Combined labels
-    ui->labelBalancez->setText(BitcoinUnits::floorHtmlWithUnit(nDisplayUnit, availableTotalBalance, false, BitcoinUnits::separatorAlways));
-    ui->labelTotalz->setText(BitcoinUnits::floorHtmlWithUnit(nDisplayUnit, sumTotalBalance, false, BitcoinUnits::separatorAlways));
-
-    // Percentage labels
-    ui->labelSCCPercent->setText(sPercentage);
-
     // Only show most balances if they are non-zero for the sake of simplicity
     QSettings settings;
     bool settingShowAllBalances = !settings.value("fHideZeroBalances").toBool();
-    bool showSumAvailable = settingShowAllBalances || sumTotalBalance != availableTotalBalance;
-    ui->labelBalanceTextz->setVisible(showSumAvailable);
-    ui->labelBalancez->setVisible(showSumAvailable);
     bool showSCCAvailable = settingShowAllBalances || phrAvailableBalance != nTotalBalance;
     bool showWatchOnlySCCAvailable = watchOnlyBalance != nTotalWatchBalance;
     bool showSCCPending = settingShowAllBalances || unconfirmedBalance != 0;

--- a/src/qt/res/css/default.css
+++ b/src/qt/res/css/default.css
@@ -955,34 +955,6 @@ font-size:14px;
 /* min-height:35px; */
 }
 
-QWidget .QFrame#frame_3 .QLabel#labelBalancez { /* Available SCC Balance */
-qproperty-alignment: 'AlignVCenter | AlignLeft';
-font-size:12px;
-font-weight:bold;
-color:#32D736;
-margin-left:0px;
-}
-
-QWidget .QFrame#frame_3 .QLabel#labelzBalanceTextz { /* Available zSCC Label */
-qproperty-alignment: 'AlignVCenter | AlignRight';
-min-width:160px;
-background-color:#32D736;
-color:#fff;
-margin-right:5px;
-padding-right:5px;
-font-weight:bold;
-font-size:14px;
-/* min-height:35px; */
-}
-
-QWidget .QFrame#frame_3 .QLabel#labelzBalancez { /* Available zSCC Balance */
-qproperty-alignment: 'AlignVCenter | AlignLeft';
-font-size:12px;
-font-weight:bold;
-color:#32D736;
-margin-left:0px;
-}
-
 QWidget .QFrame#frame_3 .QLabel#labelLockedBalanceText { /* Available zSCC Label */
 qproperty-alignment: 'AlignVCenter | AlignRight';
 min-width:160px;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1415,19 +1415,6 @@ CAmount CWalletTx::GetCredit(const isminefilter& filter) const
 CAmount CWalletTx::GetImmatureCredit(bool fUseCache) const
 {
     LOCK(cs_main);
-
-    // If MN Reward, mark as Immature until at least 1440 confirmations (temp)
-    if (IsCoinStake()) {
-        isminetype mineMN = pwallet->IsMine(vout[vout.size() - 1]);
-        if ((mineMN == ISMINE_ALL || mineMN == ISMINE_SPENDABLE) && GetDepthInMainChain() < 1440) {
-            if (fUseCache && fImmatureCreditCached)
-                return nImmatureCreditCached;
-            nImmatureCreditCached = pwallet->GetCredit(*this, ISMINE_SPENDABLE);
-            fImmatureCreditCached = true;
-            return nImmatureCreditCached;
-        }
-    }
-
     if ((IsCoinBase() || IsCoinStake()) && GetBlocksToMaturity() > 0 && IsInMainChain()) {
         if (fUseCache && fImmatureCreditCached)
             return nImmatureCreditCached;
@@ -1447,13 +1434,6 @@ CAmount CWalletTx::GetAvailableCredit(bool fUseCache) const
     // Must wait until coinbase is safely deep enough in the chain before valuing it
     if (IsCoinBase() && GetBlocksToMaturity() > 0)
         return 0;
-
-    // If MN Reward, do not value until at least 1440 confirmations (temp)
-    if (IsCoinStake()) {
-        isminetype mineMN = pwallet->IsMine(vout[vout.size() - 1]);
-        if ((mineMN == ISMINE_ALL || mineMN == ISMINE_SPENDABLE) && GetDepthInMainChain() < 1440)
-            return 0;
-    }
 
     if (fUseCache && fAvailableCreditCached)
         return nAvailableCreditCached;
@@ -1551,13 +1531,6 @@ CAmount CWalletTx::GetUnlockedCredit() const
     if (IsCoinBase() && GetBlocksToMaturity() > 0)
         return 0;
 
-    // If MN Reward, do not value until at least 1440 confirmations (temp)
-    if (IsCoinStake()) {
-        isminetype mineMN = pwallet->IsMine(vout[vout.size() - 1]);
-        if ((mineMN == ISMINE_ALL || mineMN == ISMINE_SPENDABLE) && GetDepthInMainChain() < 1440)
-            return 0;
-    }
-
     CAmount nCredit = 0;
     uint256 hashTx = GetHash();
     for (unsigned int i = 0; i < vout.size(); i++) {
@@ -1583,13 +1556,6 @@ CAmount CWalletTx::GetLockedCredit() const
     // Must wait until coinbase is safely deep enough in the chain before valuing it
     if (IsCoinBase() && GetBlocksToMaturity() > 0)
         return 0;
-
-    // If MN Reward, do not value until at least 1440 confirmations (temp)
-    if (IsCoinStake()) {
-        isminetype mineMN = pwallet->IsMine(vout[vout.size() - 1]);
-        if ((mineMN == ISMINE_ALL || mineMN == ISMINE_SPENDABLE) && GetDepthInMainChain() < 1440)
-            return 0;
-    }
 
     CAmount nCredit = 0;
     uint256 hashTx = GetHash();


### PR DESCRIPTION
To simplify the SCC QT wallet, the combined balances portion of the GUI has been removed in replacement with a single Balances form displaying total/available/immature/pending as and when necessary. Zerocoin does not exist in SCC, so the combined balances form shouldn't be required.

![image](https://user-images.githubusercontent.com/42538664/87224759-ba2d1100-c37f-11ea-823c-c81ab8f5679a.png)

This has been tested on Windows 10 x64 on a private Testnet and Mainnet (To ensure Total/Available/Immature/Pending displays properly).