### PR TITLE
[Core][Consensus] Add Tiered Coinbase Maturation

### DIFF
--- a/doc/build/build-windows.md
+++ b/doc/build/build-windows.md
@@ -1,0 +1,133 @@
+(Draft) WINDOWS BUILD NOTES
+====================
+
+Below are some notes on how to build SCC Core for Windows.
+
+The options known to work for building SCC Core on Windows are:
+
+* On Linux, using the [Mingw-w64](https://mingw-w64.org/doku.php) cross compiler tool chain. Ubuntu Bionic 18.04 is required
+and is the platform used to build the SCC Core Windows release binaries.
+* On Windows, using [Windows
+Subsystem for Linux (WSL)](https://msdn.microsoft.com/commandline/wsl/about) and the Mingw-w64 cross compiler tool chain.
+
+Other options which may work (please contribute instructions):
+
+* On Windows, using a POSIX compatibility layer application such as [cygwin](http://www.cygwin.com/) or [msys2](http://www.msys2.org/).
+* On Windows, using a native compiler tool chain such as [Visual Studio](https://www.visualstudio.com).
+
+Installing Windows Subsystem for Linux
+---------------------------------------
+
+With Windows 10, Microsoft has released a new feature named the [Windows
+Subsystem for Linux (WSL)](https://msdn.microsoft.com/commandline/wsl/about). This
+feature allows you to run a bash shell directly on Windows in an Ubuntu-based
+environment. Within this environment you can cross compile for Windows without
+the need for a separate Linux VM or server. Note that while WSL can be installed with
+other Linux variants, such as OpenSUSE, the following instructions have only been
+tested with Ubuntu.
+
+This feature is not supported in versions of Windows prior to Windows 10 or on
+Windows Server SKUs. In addition, it is available [only for 64-bit versions of
+Windows](https://msdn.microsoft.com/en-us/commandline/wsl/install_guide).
+
+Full instructions to install WSL are available on the above link.
+To install WSL on Windows 10 with Fall Creators Update installed (version >= 16215.0) do the following:
+
+1. Enable the Windows Subsystem for Linux feature
+  * Open the Windows Features dialog (`OptionalFeatures.exe`)
+  * Enable 'Windows Subsystem for Linux'
+  * Click 'OK' and restart if necessary
+2. Install Ubuntu
+  * Open Microsoft Store and search for "Ubuntu 18.04" or use [this link](https://www.microsoft.com/store/productId/9N9TNGVNDL3Q)
+  * Click Install
+3. Complete Installation
+  * Open a cmd prompt and type "Ubuntu1804"
+  * Create a new UNIX user account (this is a separate account from your Windows account)
+
+After the bash shell is active, you can follow the instructions below, starting
+with the "Cross-compilation" section. Compiling the 64-bit version is
+recommended, but it is possible to compile the 32-bit version.
+
+Cross-compilation for Ubuntu and Windows Subsystem for Linux
+------------------------------------------------------------
+
+The steps below can be performed on Ubuntu (including in a VM) or WSL. The depends system
+will also work on other Linux distributions, however the commands for
+installing the toolchain will be different.
+
+First, install the general dependencies:
+
+    sudo apt update
+    sudo apt upgrade
+    sudo apt install build-essential libtool autotools-dev automake pkg-config bsdmainutils curl git
+
+A host toolchain (`build-essential`) is necessary because some dependency
+packages (such as `protobuf`) need to build host utilities that are used in the
+build process.
+
+See [dependencies.md](dependencies.md) for a complete overview.
+
+If you want to build the windows installer with `make deploy` you need [NSIS](https://nsis.sourceforge.io/Main_Page):
+
+    sudo apt install nsis
+
+Acquire the source in the usual way:
+
+    git clone https://github.com/stakecube/StakeCubeCoin.git
+    cd StakeCubeCoin
+
+## Building for 64-bit Windows
+
+The first step is to install the mingw-w64 cross-compilation tool chain:
+
+    sudo apt install g++-mingw-w64-x86-64
+
+Ubuntu Bionic 18.04 <sup>[1](#footnote1)</sup>:
+
+    sudo update-alternatives --config x86_64-w64-mingw32-g++ # Set the default mingw32 g++ compiler option to posix.
+
+Once the toolchain is installed the build steps are common:
+
+Note that for WSL the SCC Core source path MUST be somewhere in the default mount file system, for
+example /usr/src/SCC, AND not under /mnt/d/. If this is not the case the dependency autoconf scripts will fail.
+This means you cannot use a directory that is located directly on the host Windows file system to perform the build.
+
+Build using:
+
+    PATH=$(echo "$PATH" | sed -e 's/:\/mnt.*//g') # strip out problematic Windows %PATH% imported var
+    cd depends
+    make HOST=x86_64-w64-mingw32
+    cd ..
+    ./autogen.sh # not required when building from tarball
+    CONFIG_SITE=$PWD/depends/x86_64-w64-mingw32/share/config.site ./configure --prefix=/
+    make
+
+## Depends system
+
+For further documentation on the depends system see [README.md](../depends/README.md) in the depends directory.
+
+Installation
+-------------
+
+After building using the Windows subsystem it can be useful to copy the compiled
+executables to a directory on the Windows drive in the same directory structure
+as they appear in the release `.zip` archive. This can be done in the following
+way. This will install to `c:\workspace\SCC`, for example:
+
+    make install DESTDIR=/mnt/c/workspace/SCC
+
+You can also create an installer using:
+
+    make deploy
+	
+If you get permission issues, prefix these commands with sudo.
+
+Footnotes
+---------
+
+<a name="footnote1">1</a>: Starting from Ubuntu Xenial 16.04, both the 32 and 64 bit Mingw-w64 packages install two different
+compiler options to allow a choice between either posix or win32 threads. The default option is win32 threads which is the more
+efficient since it will result in binary code that links directly with the Windows kernel32.lib. Unfortunately, the headers
+required to support win32 threads conflict with some of the classes in the C++11 standard library, in particular std::mutex.
+It's not possible to build the SCC Core code using the win32 version of the Mingw-w64 cross compilers (at least not without
+modifying headers in the SCC Core source code).

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -127,6 +127,7 @@ public:
         nTargetTimespan = 20 * 60;
         nTargetSpacing = 2 * 60;  // StakeCubeCoin: 120 seconds
         nMaturity = 25;
+        nMinStakeValue = 50; // SCC
         nMasternodeCountDrift = 20;
         nRequiredMasternodeCollateral = 1000;
         nMaxMoneyOut = 20000000 * COIN;
@@ -255,6 +256,7 @@ public:
         nTargetTimespan = 1 * 60; // StakeCubeCoin: 1 day
         nTargetSpacing = 1 * 30;  // StakeCubeCoin: 30 seconds
         nMaturity = 5;
+        nMinStakeValue = 50; // SCC
         nMasternodeCountDrift = 4;
         nModifierUpdateBlock = 51197; //approx Mon, 17 Apr 2017 04:00:00 GMT
         nRequiredMasternodeCollateral = 1000;

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -253,13 +253,16 @@ public:
         nToCheckBlockUpgradeMajority = 100;
         nMinerThreads = 0;
         nTargetTimespan = 1 * 60; // StakeCubeCoin: 1 day
-        nTargetSpacing = 1 * 60;  // StakeCubeCoin: 1 minute
+        nTargetSpacing = 1 * 30;  // StakeCubeCoin: 30 seconds
         nMaturity = 5;
         nMasternodeCountDrift = 4;
         nModifierUpdateBlock = 51197; //approx Mon, 17 Apr 2017 04:00:00 GMT
         nRequiredMasternodeCollateral = 1000;
         nMaxMoneyOut = 1000000000 * COIN;
-        nLastPOWBlock = 400;
+
+        // Height-based activations
+        nLastPOWBlock = 200;
+        nTieredCoinbaseMaturationBlock = 1450; // ~12h after genesis
 
         //! Modify the testnet genesis block so the timestamp is valid for a later start.
         genesis.nTime = 1524873600;

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -134,6 +134,7 @@ public:
         /** Height or Time Based Activations **/
         nLastPOWBlock = 200;
         nModifierUpdateBlock = 500;
+        nTieredCoinbaseMaturationBlock = 430000;
 
         /**
          * Build the genesis block. Note that the output of the genesis coinbase cannot

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -135,7 +135,7 @@ public:
         /** Height or Time Based Activations **/
         nLastPOWBlock = 200;
         nModifierUpdateBlock = 500;
-        nTieredCoinbaseMaturationBlock = 430000;
+        nTieredCoinbaseMaturationBlock = 444000;
 
         /**
          * Build the genesis block. Note that the output of the genesis coinbase cannot

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -264,7 +264,7 @@ public:
 
         // Height-based activations
         nLastPOWBlock = 200;
-        nTieredCoinbaseMaturationBlock = 1450; // ~12h after genesis
+        nTieredCoinbaseMaturationBlock = 950; // ~12h after genesis
 
         //! Modify the testnet genesis block so the timestamp is valid for a later start.
         genesis.nTime = 1524873600;

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -72,7 +72,23 @@ public:
     int64_t TargetTimespan() const { return nTargetTimespan; }
     int64_t TargetSpacing() const { return nTargetSpacing; }
     int64_t Interval() const { return nTargetTimespan / nTargetSpacing; }
-    int COINBASE_MATURITY() const { return nMaturity; }
+
+    /** Calculated dynamically based on coin value (The nTieredCoinbaseMaturationBlock upgrade) */
+    int COINBASE_MATURITY(int64_t nValue, int nBlock) const {
+        if (nBlock < nTieredCoinbaseMaturationBlock)
+            return nMaturity;
+
+        if (nValue > 0 && nValue <= 100) {
+            return 1440;
+        } else if (nValue > 100 && nValue <= 500) {
+            return 720;
+        } else if (nValue > 500 && nValue < 1000) {
+            return 360;
+        } else /* Larger than (Or Equal to) 1000 SCC */ {
+            return 180;
+        }
+    }
+
     unsigned int StakeMaturity() const { return nStakeMaturity; }
     CAmount RequiredMasternodeCollateral() const { return nRequiredMasternodeCollateral; }
     CAmount MaxMoneyOut() const { return nMaxMoneyOut; }
@@ -101,6 +117,7 @@ public:
     /** Height or Time Based Activations **/
     int ModifierUpgradeBlock() const { return nModifierUpdateBlock; }
     int LAST_POW_BLOCK() const { return nLastPOWBlock; }
+    int TieredCoinbaseMaturityBlock() const { return nTieredCoinbaseMaturationBlock; }
 
 protected:
     CChainParams() {}
@@ -122,6 +139,7 @@ protected:
     int nMaturity;
     unsigned int nStakeMaturity;
     int nModifierUpdateBlock;
+    int nTieredCoinbaseMaturationBlock;
     CAmount nRequiredMasternodeCollateral;
     CAmount nMaxMoneyOut;
     int nMinerThreads;

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -78,6 +78,7 @@ public:
         if (nBlock < nTieredCoinbaseMaturationBlock)
             return nMaturity;
 
+        nValue /= COIN;
         if (nValue > 0 && nValue <= 100) {
             return 1440;
         } else if (nValue > 100 && nValue <= 500) {

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -89,6 +89,9 @@ public:
         }
     }
 
+    /** Minimum amount of SCC (full coins) required for an input to stake, lower amounts cannot stake */
+    CAmount MinStakeValue() const { return nMinStakeValue; }
+
     unsigned int StakeMaturity() const { return nStakeMaturity; }
     CAmount RequiredMasternodeCollateral() const { return nRequiredMasternodeCollateral; }
     CAmount MaxMoneyOut() const { return nMaxMoneyOut; }
@@ -137,6 +140,7 @@ protected:
     int nLastPOWBlock;
     int nMasternodeCountDrift;
     int nMaturity;
+    CAmount nMinStakeValue;
     unsigned int nStakeMaturity;
     int nModifierUpdateBlock;
     int nTieredCoinbaseMaturationBlock;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1426,11 +1426,6 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler, const std
                     break;
                 }
 
-                if (fAddrIndex != GetBoolArg("-addrindex", true)) {
-                    strLoadError = _("You need to rebuild the database using -reindex to change -addrindex");
-                    break;
-                }
-
                 // Recalculate money supply
                 if (GetBoolArg("-reindexmoneysupply", false)) {
                     RecalculateSCCSupply(1);

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -290,7 +290,7 @@ bool stakeTargetHit(uint256 hashProofOfStake, int64_t nValueIn, uint256 bnTarget
 }
 
 //instead of looping outside and reinitializing variables many times, we will give a nTimeTx and also search interval so that we can do all the hashing here
-bool CheckStakeKernelHash(unsigned int nBits, const CBlock blockFrom, CBlockIndex pindex, const CTransaction txPrev, const COutPoint prevout, unsigned int& nTimeTx, unsigned int nHashDrift, bool fCheck, uint256& hashProofOfStake, bool fPrintProofOfStake)
+bool CheckStakeKernelHash(unsigned int nBits, const CBlock blockFrom, const CTransaction txPrev, const COutPoint prevout, unsigned int& nTimeTx, unsigned int nHashDrift, bool fCheck, uint256& hashProofOfStake, bool fPrintProofOfStake)
 {
     //assign new variables to make it easier to read
     int64_t nValueIn = txPrev.vout[prevout.n].nValue;
@@ -304,7 +304,7 @@ bool CheckStakeKernelHash(unsigned int nBits, const CBlock blockFrom, CBlockInde
         //return error("CheckStakeKernelHash() : min age violation - nTimeBlockFrom=%d nStakeMinAge=%d nTimeTx=%d", nTimeBlockFrom, nStakeMinAge, nTimeTx);
     
     // If past the Tiered Maturity upgrade, enforce minimum stake value
-    if (pindex.nHeight >= Params().TieredCoinbaseMaturityBlock()) {
+    if (chainActive.Height() >= Params().TieredCoinbaseMaturityBlock()) {
         if (nValueIn < Params().MinStakeValue() * COIN)
             return error("CheckStakeKernelHash() : nValueIn is less than minimum stake value (value: %u, min: %u)", nValueIn / COIN, Params().MinStakeValue());
     }
@@ -411,7 +411,7 @@ bool CheckProofOfStake(const CBlock block, uint256& hashProofOfStake)
 
     if (pindex->nHeight != 300)
     {
-        if (!CheckStakeKernelHash(block.nBits, blockprev, pindex, txPrev, txin.prevout, nTime, nInterval, true, hashProofOfStake, fDebug) && nTime > 1538198000)
+        if (!CheckStakeKernelHash(block.nBits, blockprev, txPrev, txin.prevout, nTime, nInterval, true, hashProofOfStake, fDebug) && nTime > 1538198000)
         {
             return error("CheckProofOfStake() : INFO: check kernel failed on coinstake %s, hashProof=%s \n", tx.GetHash().ToString().c_str(), hashProofOfStake.ToString().c_str()); // may occur during initial download or if behind on block chain sync
         }

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -409,7 +409,7 @@ bool CheckProofOfStake(const CBlock block, uint256& hashProofOfStake)
     unsigned int nInterval = 0;
     unsigned int nTime = block.nTime;
 
-    if (pindex->nHeight != 300)
+    if (pindex->nHeight >= Params().TieredCoinbaseMaturityBlock())
     {
         if (!CheckStakeKernelHash(block.nBits, blockprev, txPrev, txin.prevout, nTime, nInterval, true, hashProofOfStake, fDebug) && nTime > 1538198000)
         {

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -411,7 +411,7 @@ bool CheckProofOfStake(const CBlock block, uint256& hashProofOfStake)
 
     if (pindex->nHeight >= Params().TieredCoinbaseMaturityBlock())
     {
-        if (!CheckStakeKernelHash(block.nBits, blockprev, txPrev, txin.prevout, nTime, nInterval, true, hashProofOfStake, fDebug) && nTime > 1538198000)
+        if (!CheckStakeKernelHash(block.nBits, blockprev, txPrev, txin.prevout, nTime, nInterval, true, hashProofOfStake, fDebug))
         {
             return error("CheckProofOfStake() : INFO: check kernel failed on coinstake %s, hashProof=%s \n", tx.GetHash().ToString().c_str(), hashProofOfStake.ToString().c_str()); // may occur during initial download or if behind on block chain sync
         }

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -290,7 +290,7 @@ bool stakeTargetHit(uint256 hashProofOfStake, int64_t nValueIn, uint256 bnTarget
 }
 
 //instead of looping outside and reinitializing variables many times, we will give a nTimeTx and also search interval so that we can do all the hashing here
-bool CheckStakeKernelHash(unsigned int nBits, const CBlock blockFrom, const CTransaction txPrev, const COutPoint prevout, unsigned int& nTimeTx, unsigned int nHashDrift, bool fCheck, uint256& hashProofOfStake, bool fPrintProofOfStake)
+bool CheckStakeKernelHash(unsigned int nBits, const CBlock blockFrom, CBlockIndex pindex, const CTransaction txPrev, const COutPoint prevout, unsigned int& nTimeTx, unsigned int nHashDrift, bool fCheck, uint256& hashProofOfStake, bool fPrintProofOfStake)
 {
     //assign new variables to make it easier to read
     int64_t nValueIn = txPrev.vout[prevout.n].nValue;
@@ -302,6 +302,12 @@ bool CheckStakeKernelHash(unsigned int nBits, const CBlock blockFrom, const CTra
     if (nTimeBlockFrom + nStakeMinAge > nTimeTx) // Min age requirement
         return false;
         //return error("CheckStakeKernelHash() : min age violation - nTimeBlockFrom=%d nStakeMinAge=%d nTimeTx=%d", nTimeBlockFrom, nStakeMinAge, nTimeTx);
+    
+    // If past the Tiered Maturity upgrade, enforce minimum stake value
+    if (pindex.nHeight >= Params().TieredCoinbaseMaturityBlock()) {
+        if (nValueIn < Params().MinStakeValue() * COIN)
+            return error("CheckStakeKernelHash() : nValueIn is less than minimum stake value (value: %u, min: %u)", nValueIn / COIN, Params().MinStakeValue());
+    }
 
     //grab difficulty
     uint256 bnTargetPerCoinDay;
@@ -405,7 +411,7 @@ bool CheckProofOfStake(const CBlock block, uint256& hashProofOfStake)
 
     if (pindex->nHeight != 300)
     {
-        if (!CheckStakeKernelHash(block.nBits, blockprev, txPrev, txin.prevout, nTime, nInterval, true, hashProofOfStake, fDebug) && nTime < 1538198000)
+        if (!CheckStakeKernelHash(block.nBits, blockprev, pindex, txPrev, txin.prevout, nTime, nInterval, true, hashProofOfStake, fDebug) && nTime > 1538198000)
         {
             return error("CheckProofOfStake() : INFO: check kernel failed on coinstake %s, hashProof=%s \n", tx.GetHash().ToString().c_str(), hashProofOfStake.ToString().c_str()); // may occur during initial download or if behind on block chain sync
         }

--- a/src/kernel.h
+++ b/src/kernel.h
@@ -25,7 +25,7 @@ bool ComputeNextStakeModifier(const CBlockIndex* pindexPrev, uint64_t& nStakeMod
 // Sets hashProofOfStake on success return
 uint256 stakeHash(unsigned int nTimeTx, CDataStream ss, unsigned int prevoutIndex, uint256 prevoutHash, unsigned int nTimeBlockFrom);
 bool stakeTargetHit(uint256 hashProofOfStake, int64_t nValueIn, uint256 bnTargetPerCoinDay);
-bool CheckStakeKernelHash(unsigned int nBits, const CBlock blockFrom, CBlockIndex* pindex, const CTransaction txPrev, const COutPoint prevout, unsigned int& nTimeTx, unsigned int nHashDrift, bool fCheck, uint256& hashProofOfStake, bool fPrintProofOfStake = false);
+bool CheckStakeKernelHash(unsigned int nBits, const CBlock blockFrom, const CTransaction txPrev, const COutPoint prevout, unsigned int& nTimeTx, unsigned int nHashDrift, bool fCheck, uint256& hashProofOfStake, bool fPrintProofOfStake = false);
 
 // Check kernel hash target and coinstake signature
 // Sets hashProofOfStake on success return

--- a/src/kernel.h
+++ b/src/kernel.h
@@ -25,7 +25,7 @@ bool ComputeNextStakeModifier(const CBlockIndex* pindexPrev, uint64_t& nStakeMod
 // Sets hashProofOfStake on success return
 uint256 stakeHash(unsigned int nTimeTx, CDataStream ss, unsigned int prevoutIndex, uint256 prevoutHash, unsigned int nTimeBlockFrom);
 bool stakeTargetHit(uint256 hashProofOfStake, int64_t nValueIn, uint256 bnTargetPerCoinDay);
-bool CheckStakeKernelHash(unsigned int nBits, const CBlock blockFrom, const CTransaction txPrev, const COutPoint prevout, unsigned int& nTimeTx, unsigned int nHashDrift, bool fCheck, uint256& hashProofOfStake, bool fPrintProofOfStake = false);
+bool CheckStakeKernelHash(unsigned int nBits, const CBlock blockFrom, CBlockIndex* pindex, const CTransaction txPrev, const COutPoint prevout, unsigned int& nTimeTx, unsigned int nHashDrift, bool fCheck, uint256& hashProofOfStake, bool fPrintProofOfStake = false);
 
 // Check kernel hash target and coinstake signature
 // Sets hashProofOfStake on success return

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1885,7 +1885,7 @@ bool CheckInputs(const CTransaction& tx, CValidationState& state, const CCoinsVi
 
             // If prev is coinbase, check that it's matured
             if (coins->IsCoinBase() || coins->IsCoinStake()) {
-                if (nSpendHeight - coins->nHeight < Params().COINBASE_MATURITY())
+                if (nSpendHeight - coins->nHeight < Params().COINBASE_MATURITY(tx.GetValueOut(), coins->nHeight))
                     return state.Invalid(
                         error("CheckInputs() : tried to spend coinbase at depth %d, coinstake=%d", nSpendHeight - coins->nHeight, coins->IsCoinStake()),
                         REJECT_INVALID, "bad-txns-premature-spend-of-coinbase");

--- a/src/main.h
+++ b/src/main.h
@@ -141,7 +141,6 @@ extern bool fImporting;
 extern bool fReindex;
 extern int nScriptCheckThreads;
 extern bool fTxIndex;
-extern bool fAddrIndex;
 extern bool fIsBareMultisigStd;
 extern bool fCheckBlockIndex;
 extern unsigned int nCoinCacheSize;

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -274,8 +274,11 @@ QString TransactionDesc::toHTML(CWallet* wallet, CWalletTx& wtx, TransactionReco
         }
     }
 
-    if (wtx.IsCoinBase()) {
-        quint32 numBlocksToMaturity = Params().COINBASE_MATURITY() + 1;
+    if (wtx.IsCoinBase() || wtx.IsCoinStake()) {
+        // Todo: Maybe we should stop assuming that 'TieredCoinbaseMaturity' is ALWAYS active,
+        // it might require some additional cs_main locks though...
+        quint32 numBlocksToMaturity = Params().COINBASE_MATURITY(wtx.GetValueOut(),
+                                                                 Params().TieredCoinbaseMaturityBlock()) + 1;
         strHTML += "<br>" + tr("Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to \"not accepted\" and it won't be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.").arg(QString::number(numBlocksToMaturity)) + "<br>";
     }
 

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -131,64 +131,6 @@ void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& entry, 
     }
 }
 
-UniValue searchrawtransactions(const UniValue& params, bool fHelp)
-{
-    if (fHelp || params.size() < 1 || params.size() > 4)
-        throw runtime_error("searchrawtransactions <address> [verbose=1] [skip=0] [count=100]\n");
-    
-    if (!fAddrIndex)
-        throw JSONRPCError(RPC_MISC_ERROR, "Address index not enabled");
-    
-    if (!IsValidDestinationString(params[0].get_str()))
-        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid address");
-
-    CTxDestination dest = DecodeDestination(params[0].get_str());
-    
-    std::set<CExtDiskTxPos> setpos;
-    if (!FindTransactionsByDestination(dest, setpos))
-        throw JSONRPCError(RPC_DATABASE_ERROR, "Cannot search for address");
-    
-    int nSkip = 0;
-    int nCount = 100;
-    bool fVerbose = true;
-    if (params.size() > 1)
-        fVerbose = (params[1].get_int() != 0);
-    if (params.size() > 2)
-        nSkip = params[2].get_int();
-    if (params.size() > 3)
-        nCount = params[3].get_int();
-    
-    if (nSkip < 0)
-        nSkip += setpos.size();
-    if (nSkip < 0)
-        nSkip = 0;
-    if (nCount < 0)
-        nCount = 0;
-    
-    std::set<CExtDiskTxPos>::const_iterator it = setpos.begin();
-    while (it != setpos.end() && nSkip--) it++;
-    
-    UniValue result(UniValue::VARR);
-    while (it != setpos.end() && nCount--) {
-        CTransaction tx;
-        uint256 hashBlock;
-        if (!ReadTransaction(tx, *it, hashBlock))
-            throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "Cannot read transaction from disk");
-        if (fVerbose) {
-            UniValue object(UniValue::VOBJ);
-            TxToJSON(tx, hashBlock, object, true, RPCSerializationFlags());
-            result.push_back(object);
-        } else {
-            CDataStream ssTx(SER_NETWORK, PROTOCOL_VERSION | RPCSerializationFlags());
-            ssTx << tx;
-            string strHex = HexStr(ssTx.begin(), ssTx.end());
-            result.push_back(strHex);
-        }
-        it++;
-    }
-    return result;
-}
-
 UniValue getrawtransaction(const UniValue& params, bool fHelp)
 {
     if (fHelp || params.size() < 1 || params.size() > 2)

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -337,7 +337,6 @@ static const CRPCCommand vRPCCommands[] =
         {"rawtransactions", "decoderawtransaction", &decoderawtransaction, true, false, false},
         {"rawtransactions", "decodescript", &decodescript, true, false, false},
         {"rawtransactions", "getrawtransaction", &getrawtransaction, true, false, false},
-        {"rawtransactions", "searchrawtransactions", &searchrawtransactions, true, false, false},
         {"rawtransactions", "sendrawtransaction", &sendrawtransaction, false, false, false},
         {"rawtransactions", "signrawtransaction", &signrawtransaction, false, false, false}, /* uses wallet if enabled */
 

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -489,7 +489,7 @@ void CTxMemPool::removeCoinbaseSpends(const CCoinsViewCache* pcoins, unsigned in
                 continue;
             const CCoins* coins = pcoins->AccessCoins(txin.prevout.hash);
             if (fSanityCheck) assert(coins);
-            if (!coins || ((coins->IsCoinBase() || coins->IsCoinStake()) && nMemPoolHeight - coins->nHeight < (unsigned)Params().COINBASE_MATURITY())) {
+            if (!coins || ((coins->IsCoinBase() || coins->IsCoinStake()) && nMemPoolHeight - coins->nHeight < (unsigned)Params().COINBASE_MATURITY(tx.GetValueOut(), coins->nHeight))) {
                 transactionsToRemove.push_back(tx);
                 break;
             }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3283,7 +3283,7 @@ bool CWallet::CreateCoinStake(const CKeyStore& keystore, unsigned int nBits, int
         nTxNewTime = GetAdjustedTime();
 
         //iterates each utxo inside of CheckStakeKernelHash()
-        if (CheckStakeKernelHash(nBits, block, pindex, *pcoin.first, prevoutStake, nTxNewTime, nHashDrift, false, hashProofOfStake, true)) {
+        if (CheckStakeKernelHash(nBits, block, *pcoin.first, prevoutStake, nTxNewTime, nHashDrift, false, hashProofOfStake, true)) {
             //Double check that this will pass time requirements
             if (nTxNewTime <= chainActive.Tip()->GetMedianTimePast()) {
                 LogPrintf("CreateCoinStake() : kernel found, but it is too far in the past \n");

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2363,6 +2363,10 @@ bool CWallet::SelectStakeCoins(std::set<std::pair<const CWalletTx*, unsigned int
         if (out.nDepth < (out.tx->IsCoinStake() ? Params().COINBASE_MATURITY(out.tx->GetValueOut(), out.nDepth) : 10))
             continue;
 
+        //check that it is above the minimum stake value threshold
+        if (out.Value() < Params().MinStakeValue() * COIN)
+            continue;
+
         //add to our stake set
         setCoins.insert(make_pair(out.tx, out.i));
         nAmountSelected += out.tx->vout[out.i].nValue;
@@ -3279,7 +3283,7 @@ bool CWallet::CreateCoinStake(const CKeyStore& keystore, unsigned int nBits, int
         nTxNewTime = GetAdjustedTime();
 
         //iterates each utxo inside of CheckStakeKernelHash()
-        if (CheckStakeKernelHash(nBits, block, *pcoin.first, prevoutStake, nTxNewTime, nHashDrift, false, hashProofOfStake, true)) {
+        if (CheckStakeKernelHash(nBits, block, pindex, *pcoin.first, prevoutStake, nTxNewTime, nHashDrift, false, hashProofOfStake, true)) {
             //Double check that this will pass time requirements
             if (nTxNewTime <= chainActive.Tip()->GetMedianTimePast()) {
                 LogPrintf("CreateCoinStake() : kernel found, but it is too far in the past \n");


### PR DESCRIPTION
This system is currently set to activate at **block 430000** (As an example block, which can be changed later if desired). This system will enforce new rules on Coinbase rewards (Stakes) which adjusts a UTXOs maturation period based on its total output value, larger outputs of SCC will mature much faster than smaller outputs of SCC.

Previously, every reward had a maturation period of 25 blocks.

### The new Coinbase/Stake maturation tiers:
- 0 - 100 scc -> 1440 blocks (about 2d)
- 100 - 500 scc -> 720 blocks (about 1d)
- 500 - 1000 scc -> 360 blocks (about 0.5d)
- 1000 scc -> 180 blocks 180 (about 0.25d)

### Possible to-do's and notes:
- As this is consensus-changing, we will want to bump the protocol version and aim for a smooth upgrade.
- As this will affect how staking works, pools such as StakeCube itself will need to be adapted to recognize this tier-system, to avoid rewarding users shares for a deposit that is not yet ready for staking again (Due to not meeting the input's unique maturation period)

Code reviews and tests are heavily appreciated! - StakeCube rocks!