### PR TITLE
[Staking] [Core] Stricter Mempool Eviction

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -210,7 +210,7 @@ public:
 
         fMiningRequiresPeers = true;
         fAllowMinDifficultyBlocks = false;
-        fDefaultConsistencyChecks = false;
+        fDefaultConsistencyChecks = true;
         fRequireStandard = true;
         fMineBlocksOnDemand = false;
         fSkipProofOfWorkCheck = false;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -883,8 +883,8 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler, const std
     if (GetBoolArg("-benchmark", false))
         InitWarning(_("Warning: Unsupported argument -benchmark ignored, use -debug=bench."));
 
-    // Checkmempool and checkblockindex default to true in regtest mode
-    mempool.setSanityCheck(GetBoolArg("-checkmempool", Params().DefaultConsistencyChecks()));
+    // Checkmempool and checkblockindex default to true in testnet + regtest mode
+    mempool.setSanityCheck(GetBoolArg("-checkmempool", Params().NetworkID() != CBaseChainParams::MAIN));
     fCheckBlockIndex = GetBoolArg("-checkblockindex", Params().DefaultConsistencyChecks());
     Checkpoints::fEnabled = GetBoolArg("-checkpoints", true);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2909,7 +2909,7 @@ bool ActivateBestChain(CValidationState& state, CBlock* pblock, bool fAlreadyChe
     } while (pindexMostWork != chainActive.Tip());
 
     // Check the Block Index on a non-intensive interval to prevent massive sync slowdowns
-    if (!IsInitialBlockDownload() && pindexNewTip->nHeight % 100 == 0 && Checkpoints::GuessVerificationProgress(pindexNewTip) > 0.997 || Params().NetworkID() != CBaseChainParams::MAIN)
+    if ((!IsInitialBlockDownload() && pindexNewTip->nHeight % 100 == 0 && Checkpoints::GuessVerificationProgress(pindexNewTip) > 0.997) || Params().NetworkID() != CBaseChainParams::MAIN)
         CheckBlockIndex();
 
     // Write changes periodically to disk, after relay.
@@ -5527,7 +5527,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
             pfrom->PushMessage(NetMsgType::GETHEADERS, chainActive.GetLocator(pindexLast), uint256(0));
         }
 
-        if (!IsInitialBlockDownload() && pindexLast && pindexLast->nHeight % 100 == 0 && Checkpoints::GuessVerificationProgress(pindexLast) > 0.997 || Params().NetworkID() != CBaseChainParams::MAIN)
+        if ((!IsInitialBlockDownload() && pindexLast && pindexLast->nHeight % 100 == 0 && Checkpoints::GuessVerificationProgress(pindexLast) > 0.997) || Params().NetworkID() != CBaseChainParams::MAIN)
             CheckBlockIndex();
     }
 


### PR DESCRIPTION
This PR intends to stop invalid transactions (Standard TXs missing some inputs entirely, if any at all) from entering a staker node and causing internal problems such as segfault & assertion based crashes.

Marked as work-in-progress until properly tested for a few days by a few stakers.