### PR TITLE
[Core] Fix CheckTransaction() dupe. input scanning

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1006,6 +1006,7 @@ bool CheckTransaction(const CTransaction& tx, bool fRejectBadUTXO, CValidationSt
         if (vInOutPoints.count(txin.prevout))
             return state.DoS(100, error("CheckTransaction() : duplicate inputs"),
                 REJECT_INVALID, "bad-txns-inputs-duplicate");
+        vInOutPoints.insert(txin.prevout);
     }
 
     if (tx.IsCoinBase()) {


### PR DESCRIPTION
This PR fixes a simple issue in which `CheckTransaction()` was unable to detect duplicate inputs, as it was not storing previously-scanned inputs in the `vInOutPoints` vector.